### PR TITLE
chore: prevent postinstall script always running

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Only run this postinstall script if we're developing it.
+# (Don't run if we're importing this package as an npm dependency
+# inside a different repo)
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "Skipping install script because this is not inside a Git work tree."
+  exit 0
+fi
+
 echo ""
 echo "*** Removing submodules"
 rm -rf lib/


### PR DESCRIPTION
If this package is being installed as an npm dependency to another project e.g. (axis origin frontend (fireworks)) I'm not sure it makes sense to force the consumer to have `forge` installed.