### PR TITLE
revert chore/handle-postinstall

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Only run this postinstall script if we're developing it.
-# (Don't run if we're importing this package as an npm dependency
-# inside a different repo)
-if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-  echo "Skipping install script because this is not inside a Git work tree."
-  exit 0
-fi
-
 echo ""
 echo "*** Removing submodules"
 rm -rf lib/

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Only run this postinstall script if we're developing it.
+# (Don't run if we're importing this package as an npm dependency
+# inside a different repo)
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "Skipping install script because this is not inside a Git work tree."
+  exit 0
+fi
+
 # This script is used to release a new version of the package. It will:
 #  - Validate that the working directory is clean
 #  - Validate the version number argument

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Only run this postinstall script if we're developing it.
-# (Don't run if we're importing this package as an npm dependency
-# inside a different repo)
-if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-  echo "Skipping install script because this is not inside a Git work tree."
-  exit 0
-fi
-
 # This script is used to release a new version of the package. It will:
 #  - Validate that the working directory is clean
 #  - Validate the version number argument


### PR DESCRIPTION
When this package is used as a dep via github URL, for an unknown reason the publish command runs when we don't intend it to. Rather than hacking around this, we'll remove the change and stick to how we currently import the deployment config files.